### PR TITLE
RR-2961  Migrate Magento Plugin to use V4 of the checkout interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use of the extension requires a PayStand account offering fully-featured plans. 
 
 1.  Go to your Magento 2 root folder
 2.  `composer config repositories.paystand-magento2 git https://github.com/paystand/paystand-magento2.git`
-3.  `composer require payStand/paystandmagento:dev-master#3.0.3`
+3.  `composer require paystand/paystandmagento:dev-master#3.0.3`
 4.  `composer update`
 5.  `php bin/magento setup:upgrade`
 

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Use of the extension requires a PayStand account offering fully-featured plans. 
 
 1.  Go to your Magento 2 root folder
 2.  `composer config repositories.paystand-magento2 git https://github.com/paystand/paystand-magento2.git`
-3.  `composer require PayStand/PayStandMagento`
+3.  `composer require payStand/paystandmagento:dev-master#3.0.3`
 4.  `composer update`
 5.  `php bin/magento setup:upgrade`
 
 ##  Configuring the PayStand Payment Gateway
-1.  Go to Stores/Configuration/Payment Methods/PayStand in your Magento admin interface.
+1.  Go to Stores/Configuration/Sales/Payment Methods/PayStand in your Magento admin interface.
 2.  Enter your publishable_key, or Sandbox publishable_key that you were issued when creating your PayStand account.
 
 If you have any further questions, please email [support@paystand.com](support@paystand.com) or contact us at (800) 708-6413.

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -13,7 +13,7 @@
                 <!--<can_capture>0</can_capture>-->
                 <!--<can_authorize>0</can_authorize>-->
                 <!--<test>1</test>-->
-                <title>PayStand</title>
+                <title>Paystand</title>
                 <payment_action>true</payment_action>
                 <!--<trans_key backend_model="Magento\Config\Model\Config\Backend\Encrypted" />-->
                 <!--<trans_md5 backend_model="Magento\Config\Model\Config\Backend\Encrypted" />-->

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -2,7 +2,7 @@ var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
     // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
+    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,7 +1,7 @@
 var config = {
   paths: {
-    "paystand-prod": "https://checkout.paystand.com/v4/js/paystand.checkout",
     "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };
+// "paystand-prod": "https://checkout.paystand.com/v4/js/paystand.checkout",

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,6 +1,6 @@
 var config = {
   paths: {
-    "paystand": "https://checkout.paystand.co/v4/js/paystand.checkout",
+    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout",
     "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
-    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
+    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
+    // "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,6 +1,6 @@
 var config = {
   paths: {
-    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout",
+    "paystand": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
-    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    // "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
+    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
+    "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,7 +1,8 @@
 var config = {
   paths: {
-    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout",
-    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
+    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout?env=live",
+    //"paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout?env=sandbox",
+    "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
-    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
+    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
+    // "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,7 +1,7 @@
 var config = {
   paths: {
+    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout",
     "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };
-// "paystand-prod": "https://checkout.paystand.com/v4/js/paystand.checkout",

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,6 +1,6 @@
 var config = {
   paths: {
-    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout",
+    "paystand-prod": "https://checkout.paystand.com/v4/js/paystand.checkout",
     "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
-    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    // "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
+    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
+    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,7 +1,7 @@
 var config = {
   paths: {
-    "paystand": "https://checkout.paystand.com/v3/js/paystand.checkout",
-    "paystand-sandbox": "https://checkout.paystand.co/v3/js/paystand.checkout",
+    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout",
+    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,7 +1,7 @@
 var config = {
   paths: {
-    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout?env=live",
-    //"paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout?env=sandbox",
+    "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
+    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
     "paystand-sandbox": "https://localhost:3002/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -29,19 +29,19 @@ define([
     var quoteId = quote.getQuoteId();
     var billing = quote.billingAddress();
 
-    PayStandCheckout.checkoutComplete = function (data, iframe) {
+    psCheckout.onComplete(function(data){
       console.log("custom checkout complete:", data);
       $(".submit-trigger").click();
-    };
-    PayStandCheckout.checkoutFailed = function (data) {
-      console.log("custom checkout failed:", data);
-    };
+    });
+    psCheckout.onError(function(data){
+      console.log("custom checkout error:", data);
+    });
 
     function initCheckout(countryISO3)
     {
-      PayStandCheckout.init({
+      psCheckout.reboot({
         "publishableKey": publishable_key,
-        "checkout_domain": "https://checkout." + core_domain + "/v3/",
+        "checkout_domain": "https://checkout." + core_domain + "/v4/",
         "domain": "https://api." + core_domain,
         "payment": {
           "amount": price
@@ -67,7 +67,7 @@ define([
           "quote": quoteId,
           "quoteDetails" : quote.totals()
         }
-      }, null, 520);
+      });
       // stop observing for mutation events
       window.observer.disconnect();
     }

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -1,4 +1,4 @@
-var checkoutjs_module = 'paystand-prod';
+var checkoutjs_module = 'paystand';
 var core_domain = 'paystand.com';
 var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -46,49 +46,51 @@ define([
     function initCheckout(countryISO3)
     {
       psCheckout.onceLoaded(function (data) {
+
+        var config = {
+          "publishableKey": publishable_key,
+          "payment": {
+            "amount": price
+          },
+          "viewReceipt": "close",
+          "viewCheckout": "mobile",
+          "currency": "USD",
+          "paymentMethods": [
+            'echeck',
+            'card'
+          ],
+          "payer": {
+            "name": billing.firstname + ' ' + billing.lastname,
+            "email": quote.guestEmail
+          },
+          "payerAddressCounty": countryISO3,
+          "meta": {
+            "source": "magento 2",
+            "quote": quoteId,
+            "quoteDetails" : quote.totals()
+          }
+        };
+
+        if (billing.street && billing.street.length > 0) {
+          config.payerAddressStreet = billing.street[0];
+        }
+        if (billing.city) {
+          config.payerAddressCity = billing.city;
+        }
+        if (billing.postcode) {
+          config.payerAddressPostal = billing.postcode;
+        }
+        if (billing.regionCode) {
+          config.payerAddressState = billing.regionCode;
+        }
+
+        console.log("rebooting checkout with config", config);
+
+        psCheckout.reboot(config);
+
         psCheckout.showCheckout();
       });
 
-      var config = {
-        "publishableKey": publishable_key,
-        "payment": {
-          "amount": price
-        },
-        "viewReceipt": "close",
-        "viewCheckout": "mobile",
-        "currency": "USD",
-        "paymentMethods": [
-          'echeck',
-          'card'
-        ],
-        "payer": {
-          "name": billing.firstname + ' ' + billing.lastname,
-          "email": quote.guestEmail
-        },
-        "payerAddressCounty": countryISO3,
-        "meta": {
-          "source": "magento 2",
-          "quote": quoteId,
-          "quoteDetails" : quote.totals()
-        }
-      };
-
-      if (billing.street && billing.street.length > 0) {
-        config.payerAddressStreet = billing.street[0];
-      }
-      if (billing.city) {
-        config.payerAddressCity = billing.city;
-      }
-      if (billing.postcode) {
-        config.payerAddressPostal = billing.postcode;
-      }
-      if (billing.regionCode) {
-        config.payerAddressState = billing.regionCode;
-      }
-
-      console.log("rebooting checkout with config", config);
-
-      psCheckout.reboot(config);
       // stop observing for mutation events
       window.observer.disconnect();
     }

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -8,7 +8,7 @@ if (use_sandbox == '1') {
   // api_domain = 'api.paystand.co';
   // checkout_domain = 'checkout.paystand.co';
   // env = 'sandbox';
-  api_domain = 'localhost:3001';
+  api_domain = 'localhost:3001/api';
   checkout_domain = 'localhost:3002';
   env = 'local';
 }

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -1,13 +1,16 @@
 var checkoutjs_module = 'paystand';
+var core_domain = 'paystand.com';
 var api_domain = 'api.paystand.com';
 var checkout_domain = 'checkout.paystand.com';
 var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
+  // core_domain = 'paystand.co';
   // api_domain = 'api.paystand.co';
   // checkout_domain = 'checkout.paystand.co';
   // env = 'sandbox';
+  core_domain = 'localhost:3001';
   api_domain = 'localhost:3001/api';
   checkout_domain = 'localhost:3002';
   env = 'local';
@@ -54,7 +57,7 @@ define([
         "publishableKey": publishable_key,
         "checkout_domain": "https://" + checkout_domain + "/v4/",
         "env": env,
-        "domain": "https://" + api_domain,
+        "domain": "https://" + core_domain,
         "payment": {
           "amount": price
         },

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -86,8 +86,6 @@ define([
         config.payerAddressState = billing.regionCode;
       }
 
-      console.log(config);
-
       psCheckout.reboot(config);
       // stop observing for mutation events
       window.observer.disconnect();

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -39,22 +39,23 @@ define([
     var quoteId = quote.getQuoteId();
     var billing = quote.billingAddress();
 
-    psCheckout.onComplete(function (data) {
+    psCheckout.onComplete(function(data){
       console.log("custom checkout complete:", data);
       $(".submit-trigger").click();
     });
-    psCheckout.onError(function (data) {
+    psCheckout.onError(function(data){
       console.log("custom checkout error:", data);
     });
 
-    function initCheckout(countryISO3) {
+    function initCheckout(countryISO3)
+    {
       psCheckout.onceLoaded(function (data) {
         psCheckout.showCheckout();
       });
 
       var config = {
         "publishableKey": publishable_key,
-        "checkout_domain": "https://" + checkout_domain + "/v4",
+        "checkout_domain": "https://" + checkout_domain + "/v4/",
         "env": env,
         "domain": "https://" + core_domain,
         "payment": {
@@ -69,26 +70,19 @@ define([
           "name": billing.firstname + ' ' + billing.lastname,
           "email": quote.guestEmail
         },
-        "payerAddressCountry": countryISO3,
+        "billing": {
+          "street": billing.street[0],
+          "city": billing.city,
+          "postalCode": billing.postcode,
+          "subdivisionCode": billing.regionCode,
+          "countryCode": countryISO3
+        },
         "meta": {
           "source": "magento 2",
           "quote": quoteId,
-          "quoteDetails": quote.totals()
+          "quoteDetails" : quote.totals()
         }
       };
-
-      if (billing.street && billing.street.length > 0) {
-        config.payerAddressStreet = billing.street[0];
-      }
-      if (billing.city) {
-        config.payerAddressCity = billing.city;
-      }
-      if (billing.postcode) {
-        config.payerAddressPostal = billing.postcode;
-      }
-      if (billing.regionCode) {
-        config.payerAddressState = billing.regionCode;
-      }
 
       console.log(config);
 

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -5,12 +5,12 @@ var checkout_domain = 'checkout.paystand.com';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  core_domain = 'paystand.co';
-  api_domain = 'api.paystand.co';
-  checkout_domain = 'checkout.paystand.co';
-  // core_domain = 'localhost:3001';
-  // api_domain = 'localhost:3001/api';
-  // checkout_domain = 'localhost:3003';
+  // core_domain = 'paystand.co';
+  // api_domain = 'api.paystand.co';
+  // checkout_domain = 'checkout.paystand.co';
+  core_domain = 'localhost:3001';
+  api_domain = 'localhost:3001/api';
+  checkout_domain = 'localhost:3002';
 }
 
 /*jshint browser:true jquery:true*/
@@ -48,22 +48,16 @@ define([
 
       var config = {
         "publishableKey": publishable_key,
-        "payment": {
-          "amount": price
-        },
+        "paymentAmount": price,
+        "fixedAmount": true,
         "viewReceipt": "close",
         "viewCheckout": "mobile",
-        "currency": "USD",
-        "paymentMethods": [
-          'echeck',
-          'card'
-        ],
-        "payer": {
-          "name": billing.firstname + ' ' + billing.lastname,
-          "email": quote.guestEmail
-        },
+        "paymentCurrency": "USD",
+        "viewFunds": "echeck,card",
+        "payerName": billing.firstname + ' ' + billing.lastname,
+        "payerEmail": quote.guestEmail,
         "payerAddressCounty": countryISO3,
-        "meta": {
+        "paymentMeta": {
           "source": "magento 2",
           "quote": quoteId,
           "quoteDetails" : quote.totals()

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -1,9 +1,11 @@
 var checkoutjs_module = 'paystand';
 var core_domain = 'paystand.com';
+var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
   core_domain = 'paystand.co';
+  env = 'sandbox';
 }
 
 /*jshint browser:true jquery:true*/
@@ -46,6 +48,7 @@ define([
       psCheckout.reboot({
         "publishableKey": publishable_key,
         "checkout_domain": "https://checkout." + core_domain + "/v4/",
+        "env": env,
         "domain": "https://api." + core_domain,
         "payment": {
           "amount": price

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -4,8 +4,10 @@ var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  core_domain = 'paystand.co';
-  env = 'sandbox';
+  // core_domain = 'paystand.co';
+  // env = 'sandbox';
+  core_domain = 'localhost:3002';
+  env = 'local';
 }
 
 /*jshint browser:true jquery:true*/

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -52,20 +52,11 @@ define([
         psCheckout.showCheckout();
       });
 
-      console.log("billing",billing);
-
-      var street = "";
-      if (billing.street && billing.street.length > 0) {
-        street = billing.street[0];
-      }
-
       var config = {
         "publishableKey": publishable_key,
         "checkout_domain": "https://" + checkout_domain + "/v4/",
         "env": env,
         "domain": "https://" + core_domain,
-        "viewClose": false,
-        "viewLogo": false,
         "payment": {
           "amount": price
         },
@@ -78,19 +69,26 @@ define([
           "name": billing.firstname + ' ' + billing.lastname,
           "email": quote.guestEmail
         },
-        "billing": {
-          "street": street,
-          "city": billing.city,
-          "postalCode": billing.postcode,
-          "subdivisionCode": billing.regionCode,
-          "countryCode": countryISO3
-        },
+        "payerAddressCountry": countryISO3,
         "meta": {
           "source": "magento 2",
           "quote": quoteId,
           "quoteDetails": quote.totals()
         }
       };
+
+      if (billing.street && billing.street.length > 0) {
+        config.payerAddressStreet = billing.street[0];
+      }
+      if (billing.city) {
+        config.payerAddressCity = billing.city;
+      }
+      if (billing.postcode) {
+        config.payerAddressPostal = billing.postcode;
+      }
+      if (billing.regionCode) {
+        config.payerAddressState = billing.regionCode;
+      }
 
       console.log(config);
 

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -54,7 +54,7 @@ define([
 
       var config = {
         "publishableKey": publishable_key,
-        "checkout_domain": "https://" + checkout_domain + "/v4/",
+        "checkout_domain": "https://" + checkout_domain + "/v4",
         "env": env,
         "domain": "https://" + core_domain,
         "payment": {

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -2,18 +2,15 @@ var checkoutjs_module = 'paystand';
 var core_domain = 'paystand.com';
 var api_domain = 'api.paystand.com';
 var checkout_domain = 'checkout.paystand.com';
-var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
   // core_domain = 'paystand.co';
   // api_domain = 'api.paystand.co';
   // checkout_domain = 'checkout.paystand.co';
-  // env = 'sandbox';
   core_domain = 'localhost:3001';
   api_domain = 'localhost:3001/api';
   checkout_domain = 'localhost:3002';
-  env = 'local';
 }
 
 /*jshint browser:true jquery:true*/
@@ -33,7 +30,6 @@ define([
   var loadPaystandCheckout = function () {
 
     var publishable_key = window.checkoutConfig.payment.paystandmagento.publishable_key;
-    console.log("publishable key = " + publishable_key);
 
     var price = quote.totals().grand_total.toString();
     var quoteId = quote.getQuoteId();
@@ -55,9 +51,6 @@ define([
 
       var config = {
         "publishableKey": publishable_key,
-        "checkout_domain": "https://" + checkout_domain + "/v4/",
-        "env": env,
-        "domain": "https://" + core_domain,
         "payment": {
           "amount": price
         },
@@ -70,19 +63,26 @@ define([
           "name": billing.firstname + ' ' + billing.lastname,
           "email": quote.guestEmail
         },
-        "billing": {
-          "street": billing.street[0],
-          "city": billing.city,
-          "postalCode": billing.postcode,
-          "subdivisionCode": billing.regionCode,
-          "countryCode": countryISO3
-        },
+        "payerAddressCounty": countryISO3,
         "meta": {
           "source": "magento 2",
           "quote": quoteId,
           "quoteDetails" : quote.totals()
         }
       };
+
+      if (billing.street && billing.street.length > 0) {
+        config.payerAddressStreet = billing.street[0];
+      }
+      if (billing.city) {
+        config.payerAddressCity = billing.city;
+      }
+      if (billing.postcode) {
+        config.payerAddressPostal = billing.postcode;
+      }
+      if (billing.regionCode) {
+        config.payerAddressState = billing.regionCode;
+      }
 
       console.log(config);
 

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -39,6 +39,10 @@ define([
 
     function initCheckout(countryISO3)
     {
+      psCheckout.onceLoaded(function (data) {
+        psCheckout.showCheckout();
+      });
+
       psCheckout.reboot({
         "publishableKey": publishable_key,
         "checkout_domain": "https://checkout." + core_domain + "/v4/",

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -58,6 +58,8 @@ define([
         "checkout_domain": "https://" + checkout_domain + "/v4/",
         "env": env,
         "domain": "https://" + core_domain,
+        "viewClose": false,
+        "viewLogo": false,
         "payment": {
           "amount": price
         },

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -56,7 +56,6 @@ define([
         },
         "viewReceipt": "close",
         "viewCheckout": "mobile",
-        "viewLogo": false,
         "currency": "USD",
         "paymentMethods": [
           'echeck',

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -1,12 +1,15 @@
 var checkoutjs_module = 'paystand';
-var core_domain = 'paystand.com';
+var api_domain = 'api.paystand.com';
+var checkout_domain = 'checkout.paystand.com';
 var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  // core_domain = 'paystand.co';
+  // api_domain = 'api.paystand.co';
+  // checkout_domain = 'checkout.paystand.co';
   // env = 'sandbox';
-  core_domain = 'localhost:3002';
+  api_domain = 'localhost:3001';
+  checkout_domain = 'localhost:3002';
   env = 'local';
 }
 
@@ -49,9 +52,9 @@ define([
 
       psCheckout.reboot({
         "publishableKey": publishable_key,
-        "checkout_domain": "https://checkout." + core_domain + "/v4/",
+        "checkout_domain": "https://" + checkout_domain + "/v4/",
         "env": env,
-        "domain": "https://api." + core_domain,
+        "domain": "https://" + api_domain,
         "payment": {
           "amount": price
         },
@@ -88,7 +91,7 @@ define([
         },
         dataType: "text",
         contentType: "application/json; charset=utf-8",
-        url: "https://api." + core_domain + "/v3/addresses/countries/iso?code=" + billing.countryId,
+        url: "https://" + api_domain + "/v3/addresses/countries/iso?code=" + billing.countryId,
         success: function (data) {
           initCheckout(JSON.parse(data).iso3);
         },

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -5,12 +5,12 @@ var checkout_domain = 'checkout.paystand.com';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  // core_domain = 'paystand.co';
-  // api_domain = 'api.paystand.co';
-  // checkout_domain = 'checkout.paystand.co';
-  core_domain = 'localhost:3001';
-  api_domain = 'localhost:3001/api';
-  checkout_domain = 'localhost:3002';
+  core_domain = 'paystand.co';
+  api_domain = 'api.paystand.co';
+  checkout_domain = 'checkout.paystand.co';
+  // core_domain = 'localhost:3001';
+  // api_domain = 'localhost:3001/api';
+  // checkout_domain = 'localhost:3002';
 }
 
 /*jshint browser:true jquery:true*/

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -54,6 +54,9 @@ define([
         "payment": {
           "amount": price
         },
+        "viewReceipt": "close",
+        "viewCheckout": "mobile",
+        "viewLogo": false,
         "currency": "USD",
         "paymentMethods": [
           'echeck',

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -45,7 +45,7 @@ define([
 
     function initCheckout(countryISO3)
     {
-      psCheckout.onceLoaded(function (data) {
+      psCheckout.onReady(function (data) {
 
         psCheckout.onceLoaded(function (data) {
           psCheckout.showCheckout();

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -5,12 +5,12 @@ var checkout_domain = 'checkout.paystand.com';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  core_domain = 'paystand.co';
-  api_domain = 'api.paystand.co';
-  checkout_domain = 'checkout.paystand.co';
-  // core_domain = 'localhost:3001';
-  // api_domain = 'localhost:3001/api';
-  // checkout_domain = 'localhost:3002';
+  // core_domain = 'paystand.co';
+  // api_domain = 'api.paystand.co';
+  // checkout_domain = 'checkout.paystand.co';
+  core_domain = 'localhost:3001';
+  api_domain = 'localhost:3001/api';
+  checkout_domain = 'localhost:3003';
 }
 
 /*jshint browser:true jquery:true*/

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -1,4 +1,4 @@
-var checkoutjs_module = 'paystand';
+var checkoutjs_module = 'paystand-prod';
 var core_domain = 'paystand.com';
 var env = 'live';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -5,12 +5,12 @@ var checkout_domain = 'checkout.paystand.com';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  // core_domain = 'paystand.co';
-  // api_domain = 'api.paystand.co';
-  // checkout_domain = 'checkout.paystand.co';
-  core_domain = 'localhost:3001';
-  api_domain = 'localhost:3001/api';
-  checkout_domain = 'localhost:3003';
+  core_domain = 'paystand.co';
+  api_domain = 'api.paystand.co';
+  checkout_domain = 'checkout.paystand.co';
+  // core_domain = 'localhost:3001';
+  // api_domain = 'localhost:3001/api';
+  // checkout_domain = 'localhost:3003';
 }
 
 /*jshint browser:true jquery:true*/

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -86,6 +86,8 @@ define([
         config.payerAddressState = billing.regionCode;
       }
 
+      console.log("rebooting checkout with config", config);
+
       psCheckout.reboot(config);
       // stop observing for mutation events
       window.observer.disconnect();

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -39,19 +39,25 @@ define([
     var quoteId = quote.getQuoteId();
     var billing = quote.billingAddress();
 
-    psCheckout.onComplete(function(data){
+    psCheckout.onComplete(function (data) {
       console.log("custom checkout complete:", data);
       $(".submit-trigger").click();
     });
-    psCheckout.onError(function(data){
+    psCheckout.onError(function (data) {
       console.log("custom checkout error:", data);
     });
 
-    function initCheckout(countryISO3)
-    {
+    function initCheckout(countryISO3) {
       psCheckout.onceLoaded(function (data) {
         psCheckout.showCheckout();
       });
+
+      console.log("billing",billing);
+
+      var street = "";
+      if (billing.street && billing.street.length > 0) {
+        street = billing.street[0];
+      }
 
       var config = {
         "publishableKey": publishable_key,
@@ -73,7 +79,7 @@ define([
           "email": quote.guestEmail
         },
         "billing": {
-          "street": billing.street[0],
+          "street": street,
           "city": billing.city,
           "postalCode": billing.postcode,
           "subdivisionCode": billing.regionCode,
@@ -82,7 +88,7 @@ define([
         "meta": {
           "source": "magento 2",
           "quote": quoteId,
-          "quoteDetails" : quote.totals()
+          "quoteDetails": quote.totals()
         }
       };
 

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -10,7 +10,7 @@ if (use_sandbox == '1') {
   // checkout_domain = 'checkout.paystand.co';
   core_domain = 'localhost:3001';
   api_domain = 'localhost:3001/api';
-  checkout_domain = 'localhost:3002';
+  checkout_domain = 'localhost:3003';
 }
 
 /*jshint browser:true jquery:true*/

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -50,7 +50,7 @@ define([
         psCheckout.showCheckout();
       });
 
-      psCheckout.reboot({
+      var config = {
         "publishableKey": publishable_key,
         "checkout_domain": "https://" + checkout_domain + "/v4/",
         "env": env,
@@ -79,7 +79,11 @@ define([
           "quote": quoteId,
           "quoteDetails" : quote.totals()
         }
-      });
+      };
+
+      console.log(config);
+
+      psCheckout.reboot(config);
       // stop observing for mutation events
       window.observer.disconnect();
     }

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -45,54 +45,54 @@ define([
 
     function initCheckout(countryISO3)
     {
-      psCheckout.onReady(function (data) {
 
+      var config = {
+        "publishableKey": publishable_key,
+        "payment": {
+          "amount": price
+        },
+        "viewReceipt": "close",
+        "viewCheckout": "mobile",
+        "currency": "USD",
+        "paymentMethods": [
+          'echeck',
+          'card'
+        ],
+        "payer": {
+          "name": billing.firstname + ' ' + billing.lastname,
+          "email": quote.guestEmail
+        },
+        "payerAddressCounty": countryISO3,
+        "meta": {
+          "source": "magento 2",
+          "quote": quoteId,
+          "quoteDetails" : quote.totals()
+        }
+      };
+
+      if (billing.street && billing.street.length > 0) {
+        config.payerAddressStreet = billing.street[0];
+      }
+      if (billing.city) {
+        config.payerAddressCity = billing.city;
+      }
+      if (billing.postcode) {
+        config.payerAddressPostal = billing.postcode;
+      }
+      if (billing.regionCode) {
+        config.payerAddressState = billing.regionCode;
+      }
+
+      console.log("rebooting checkout with config", config);
+
+      psCheckout.onceLoaded(function (data) {
         psCheckout.onceLoaded(function (data) {
           psCheckout.showCheckout();
         });
-
-        var config = {
-          "publishableKey": publishable_key,
-          "payment": {
-            "amount": price
-          },
-          "viewReceipt": "close",
-          "viewCheckout": "mobile",
-          "currency": "USD",
-          "paymentMethods": [
-            'echeck',
-            'card'
-          ],
-          "payer": {
-            "name": billing.firstname + ' ' + billing.lastname,
-            "email": quote.guestEmail
-          },
-          "payerAddressCounty": countryISO3,
-          "meta": {
-            "source": "magento 2",
-            "quote": quoteId,
-            "quoteDetails" : quote.totals()
-          }
-        };
-
-        if (billing.street && billing.street.length > 0) {
-          config.payerAddressStreet = billing.street[0];
-        }
-        if (billing.city) {
-          config.payerAddressCity = billing.city;
-        }
-        if (billing.postcode) {
-          config.payerAddressPostal = billing.postcode;
-        }
-        if (billing.regionCode) {
-          config.payerAddressState = billing.regionCode;
-        }
-
-        console.log("rebooting checkout with config", config);
-
         psCheckout.reboot(config);
-
       });
+
+      psCheckout.reboot(config);
 
       // stop observing for mutation events
       window.observer.disconnect();

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -47,6 +47,10 @@ define([
     {
       psCheckout.onceLoaded(function (data) {
 
+        psCheckout.onceLoaded(function (data) {
+          psCheckout.showCheckout();
+        });
+
         var config = {
           "publishableKey": publishable_key,
           "payment": {
@@ -88,7 +92,6 @@ define([
 
         psCheckout.reboot(config);
 
-        psCheckout.showCheckout();
       });
 
       // stop observing for mutation events

--- a/view/frontend/web/template/payment/paystandmagento-directpost.html
+++ b/view/frontend/web/template/payment/paystandmagento-directpost.html
@@ -10,7 +10,7 @@
     </div>
     <div class="payment-method-content">
         <div class="actions-toolbar">
-            <div id="paystand_checkout"></div>
+            <div id="ps_checkout"></div>
             <form class="form paystand-checkout-form" action="#" method="post">
                 <input class="submit-trigger" type="hidden" data-bind="click: placeOrder, enable: (getCode() == isChecked())"/>
             </form>


### PR DESCRIPTION
jira
---
https://paystand.atlassian.net/browse/RR-2961

description
---
Update checkout in Magento 2 to checkout v4

to qa
---
The magento 2 server is temporarily set up to point "sandbox mode" to local checkout.
Checkout the fifi branch from https://github.com/paystand/fifilafume/pull/1634 on your local and do gulp config and gulp serve (so checkout is available at localhost:3002)
Login to the Magento admin at magento.paystand.co/admin_lrjdby using username admin and password %+%[&<9YtHE@J~oc2%Z[
Go to the payment method configuration at Stores/Configuration/Sales/Payment Methods/Paystand and set sandbox mode to off and input a valid production publishableKey (we are not going to check out with this, just verify that checkout v4 loads).  Also verify that Paystand is the only payment method enabled.
In an incognito window, go to magento.paystand.co and add an item to your cart and go through the checkout processs until you get to the part where paystand checkout loads in a modal.  verify that the checkout is loaded with the live environment.
Go back to the payment method configuration and change the publishableKey to a local one and turn sandbox mode on.
Back in the incognito window, reload magento.paystand.co, then click on your cart, and go through the checkout process until checkout v4 loads with the local environment.
Complete checkout and verify that the modal closes on complete and that the magento interface takes you to a receipt page.
Back in payment method configuration turn on the card/check rail so that there will be a competing payment method.
Verify that the paystand checkout works in the case where a user clicks the radio button for cash/echeck, then clicks on the radio button for Paystand.