### PR TITLE
PPL-132  [Plugin] Magento plugin not displaying all rails

### DIFF
--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -53,7 +53,6 @@ define([
         "viewReceipt": "close",
         "viewCheckout": "mobile",
         "paymentCurrency": "USD",
-        "viewFunds": "echeck,card",
         "payerName": billing.firstname + ' ' + billing.lastname,
         "payerEmail": quote.guestEmail,
         "payerAddressCounty": countryISO3,


### PR DESCRIPTION
jira
---
https://paystand.atlassian.net/browse/PPL-132

description
---
allow all three rails to display in checkout

to qa
---
just load up magento connected to a paystand customer in good standing (access to all three rails) and verify when loading checkout that all three rails appear