### PR TITLE
PPL-133

### DIFF
--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -120,7 +120,7 @@ class Paystand extends \Magento\Framework\App\Action\Action
                 $storeScope = \Magento\Store\Model\ScopeInterface::SCOPE_STORE;
 
                 if ($this->scopeConfig->getValue(self::USE_SANDBOX, $storeScope)) {
-                    $base_url = 'https://legacy:3001/api/v3';
+                    $base_url = 'https://api.paystand.co/v3';
                 } else {
                     $base_url = 'https://api.paystand.com/v3';
                 }

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -16,6 +16,11 @@ class Paystand extends \Magento\Framework\App\Action\Action
     const PUBLISHABLE_KEY = 'payment/paystandmagento/publishable_key';
 
   /**
+   * client secret config path
+   */
+    const CUSTOMER_ID = 'payment/paystandmagento/customer_id';
+
+  /**
    * client id config path
    */
     const CLIENT_ID = 'payment/paystandmagento/client_id';

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -133,6 +133,13 @@ class Paystand extends \Magento\Framework\App\Action\Action
                 $this->http_response_code = "0"; //Restart http response
                 $url = $base_url . "/events/" . $json->id . "/verify";
 
+                // Clean up json before sending for verification
+                unset($json->sent);
+                unset($json->lastAttemptSent);
+                unset($json->attempts);
+                unset($json->sourceId);
+                unset($json->sourceType);
+
                 $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header);
                 $response = $this->runCurl($curl);
 
@@ -142,8 +149,8 @@ class Paystand extends \Magento\Framework\App\Action\Action
                     if ($json->resource->object = "payment") {
                         switch ($json->resource->status) {
                             case 'posted':
-                                $state = 'pending';
-                                $status = 'pending';
+                                $state = 'processing';
+                                $status = 'processing';
                                 break;
                             case 'paid':
                                 $state = 'processing';

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -93,7 +93,9 @@ class Paystand extends \Magento\Framework\App\Action\Action
                 }
 
                 $url = $base_url . "/events/" . $json->id . "/verify";
-                $auth_header = ["x-publishable-key: ".$this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope)];
+                $auth_header = ["x-publishable-key: ".$this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope)
+                                "client_id: ".$this->scopeConfig->getValue(self::CLIENT_ID, $storeScope)
+                                "client_secret: ".$this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope)];
 
                 $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header);
                 $response = $this->runCurl($curl);

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -5,6 +5,7 @@ namespace PayStand\PayStandMagento\Controller\Webhook;
 use \Magento\Framework\App\Config\ScopeConfigInterface as ScopeConfig;
 use \Magento\Quote\Model\QuoteFactory as QuoteFactory;
 use \Magento\Quote\Model\QuoteIdMaskFactory as QuoteIdMaskFactory;
+use \stdClass;
 
 /**
  * Webhook Receiver Controller for Paystand
@@ -134,11 +135,10 @@ class Paystand extends \Magento\Framework\App\Action\Action
                 $url = $base_url . "/events/" . $json->id . "/verify";
 
                 // Clean up json before sending for verification
-                unset($json->sent);
-                unset($json->lastAttemptSent);
-                unset($json->attempts);
-                unset($json->sourceId);
-                unset($json->sourceType);
+                $attributeWhitelist = ["id","object","resource","diff","urls","created"
+                                        ,"lastUpdated","status","sent","lastAttemptSent"
+                                        ,"attempts","sourceId","sourceType"];
+                $json = $this->cleanObject($json,$attributeWhitelist);
 
                 $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header);
                 $response = $this->runCurl($curl);
@@ -215,5 +215,14 @@ class Paystand extends \Magento\Framework\App\Action\Action
         $this->raw_response = $raw_response;
         $this->http_response_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         return $response;
+    }
+
+    private function cleanObject($obj, $whitelist)
+    {
+        $ret = new stdClass;
+        foreach ($whitelist as $prop) {
+            $ret->$prop = $obj->$prop;
+        }
+        return $ret;
     }
 }

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -16,6 +16,16 @@ class Paystand extends \Magento\Framework\App\Action\Action
     const PUBLISHABLE_KEY = 'payment/paystand_paystandmagento/publishable_key';
 
   /**
+   * client id config path
+   */
+    const CLIENT_ID = 'payment/paystandmagento/client_id';
+
+  /**
+   * client secret config path
+   */
+    const CLIENT_SECRET = 'payment/paystandmagento/client_secret';
+
+  /**
    * use sandbox config path
    */
     const USE_SANDBOX = 'payment/paystand_paystandmagento/use_sandbox';

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -18,12 +18,12 @@ class Paystand extends \Magento\Framework\App\Action\Action
   /**
    * client id config path
    */
-    const CLIENT_ID = 'payment/paystandmagento/client_id';
+    const CLIENT_ID = 'payment/paystand_paystandmagento/client_id';
 
   /**
    * client secret config path
    */
-    const CLIENT_SECRET = 'payment/paystandmagento/client_secret';
+    const CLIENT_SECRET = 'payment/paystand_paystandmagento/client_secret';
 
   /**
    * use sandbox config path
@@ -103,11 +103,11 @@ class Paystand extends \Magento\Framework\App\Action\Action
                 }
 
                 $url = $base_url . "/events/" . $json->id . "/verify";
-                $auth_header = ["x-publishable-key: ".$this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope)
-                                "client_id: ".$this->scopeConfig->getValue(self::CLIENT_ID, $storeScope)
-                                "client_secret: ".$this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope)];
+                $auth_header = ["x-publishable-key: ".$this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope)];
+                $client_id_secret = ["client_id: ".$this->scopeConfig->getValue(self::CLIENT_ID, $storeScope),
+                                     "client_secret: ".$this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope)];
 
-                $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header);
+                $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header, $client_id_secret);
                 $response = $this->runCurl($curl);
 
                 $this->_logger->addDebug("http_response_code is ".$this->http_response_code);
@@ -146,7 +146,7 @@ class Paystand extends \Magento\Framework\App\Action\Action
         }
     }
 
-    private function buildCurl($verb = "POST", $url, $body = "", $extheaders = null)
+    private function buildCurl($verb = "POST", $url, $body = "", $extheaders = null, $client_id_secret = null)
     {
         $headers = [
         "Content-Type: application/json",
@@ -155,6 +155,10 @@ class Paystand extends \Magento\Framework\App\Action\Action
 
         if (null != $extheaders) {
             $headers = array_merge($headers, $extheaders);
+        }
+
+        if (null != $client_id_secret) {
+            $body = array_merge($body, $client_id_secret);
         }
 
         $curl = curl_init();

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -13,22 +13,22 @@ class Paystand extends \Magento\Framework\App\Action\Action
   /**
    * publishable key config path
    */
-    const PUBLISHABLE_KEY = 'payment/paystand_paystandmagento/publishable_key';
+    const PUBLISHABLE_KEY = 'payment/paystandmagento/publishable_key';
 
   /**
    * client id config path
    */
-    const CLIENT_ID = 'payment/paystand_paystandmagento/client_id';
+    const CLIENT_ID = 'payment/paystandmagento/client_id';
 
   /**
    * client secret config path
    */
-    const CLIENT_SECRET = 'payment/paystand_paystandmagento/client_secret';
+    const CLIENT_SECRET = 'payment/paystandmagento/client_secret';
 
   /**
    * use sandbox config path
    */
-    const USE_SANDBOX = 'payment/paystand_paystandmagento/use_sandbox';
+    const USE_SANDBOX = 'payment/paystandmagento/use_sandbox';
 
   /** @var \Psr\Log\LoggerInterface  */
     protected $_logger;
@@ -104,10 +104,11 @@ class Paystand extends \Magento\Framework\App\Action\Action
 
                 $url = $base_url . "/events/" . $json->id . "/verify";
                 $auth_header = ["x-publishable-key: ".$this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope)];
-                $client_id_secret = ["client_id: ".$this->scopeConfig->getValue(self::CLIENT_ID, $storeScope),
-                                     "client_secret: ".$this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope)];
 
-                $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header, $client_id_secret);
+                $json->client_id = $this->scopeConfig->getValue(self::CLIENT_ID, $storeScope);
+                $json->client_secret = $this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope);
+
+                $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header);
                 $response = $this->runCurl($curl);
 
                 $this->_logger->addDebug("http_response_code is ".$this->http_response_code);
@@ -146,7 +147,7 @@ class Paystand extends \Magento\Framework\App\Action\Action
         }
     }
 
-    private function buildCurl($verb = "POST", $url, $body = "", $extheaders = null, $client_id_secret = null)
+    private function buildCurl($verb = "POST", $url, $body = "", $extheaders = null)
     {
         $headers = [
         "Content-Type: application/json",
@@ -155,10 +156,6 @@ class Paystand extends \Magento\Framework\App\Action\Action
 
         if (null != $extheaders) {
             $headers = array_merge($headers, $extheaders);
-        }
-
-        if (null != $client_id_secret) {
-            $body = array_merge($body, $client_id_secret);
         }
 
         $curl = curl_init();

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -141,8 +141,7 @@ class Paystand extends \Magento\Framework\App\Action\Action
 
                 // Clean up json before sending for verification
                 $attributeWhitelist = ["id","object","resource","diff","urls","created"
-                                        ,"lastUpdated","status","sent","lastAttemptSent"
-                                        ,"attempts","sourceId","sourceType"];
+                                                        ,"lastUpdated","status"];
                 $json = $this->cleanObject($json,$attributeWhitelist);
 
                 $curl = $this->buildCurl("POST", $url, json_encode($json), $auth_header);

--- a/Model/PayStandConfigProvider.php
+++ b/Model/PayStandConfigProvider.php
@@ -18,6 +18,16 @@ class PayStandConfigProvider implements ConfigProviderInterface
     const PUBLISHABLE_KEY = 'payment/paystandmagento/publishable_key';
 
   /**
+   * client id config path
+   */
+    const CLIENT_ID = 'payment/paystandmagento/client_id';
+
+  /**
+   * client secret config path
+   */
+    const CLIENT_SECRET = 'payment/paystandmagento/client_secret';
+
+  /**
    * use sandbox config path
    */
     const USE_SANDBOX = 'payment/paystandmagento/use_sandbox';

--- a/Model/PayStandConfigProvider.php
+++ b/Model/PayStandConfigProvider.php
@@ -18,6 +18,11 @@ class PayStandConfigProvider implements ConfigProviderInterface
     const PUBLISHABLE_KEY = 'payment/paystandmagento/publishable_key';
 
   /**
+   * client secret config path
+   */
+    const CUSTOMER_ID = 'payment/paystandmagento/customer_id';
+
+  /**
    * client id config path
    */
     const CLIENT_ID = 'payment/paystandmagento/client_id';
@@ -51,6 +56,7 @@ class PayStandConfigProvider implements ConfigProviderInterface
         'payment' => [
         'paystandmagento' => [
           'publishable_key' => $this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope),
+          'customer_id' => $this->scopeConfig->getValue(self::CUSTOMER_ID, $storeScope),
           'client_id' => $this->scopeConfig->getValue(self::CLIENT_ID, $storeScope),
           'client_secret' => $this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope),
           'use_sandbox' => $this->scopeConfig->getValue(self::USE_SANDBOX, $storeScope)

--- a/Model/PayStandConfigProvider.php
+++ b/Model/PayStandConfigProvider.php
@@ -41,6 +41,8 @@ class PayStandConfigProvider implements ConfigProviderInterface
         'payment' => [
         'paystandmagento' => [
           'publishable_key' => $this->scopeConfig->getValue(self::PUBLISHABLE_KEY, $storeScope),
+          'client_id' => $this->scopeConfig->getValue(self::CLIENT_ID, $storeScope),
+          'client_secret' => $this->scopeConfig->getValue(self::CLIENT_SECRET, $storeScope),
           'use_sandbox' => $this->scopeConfig->getValue(self::USE_SANDBOX, $storeScope)
         ]
         ]

--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -1,5 +1,5 @@
 <?php
-namespace PayStand\PayStandMagento\Plugin\CsrfValidatorSkip;
+namespace PayStand\PayStandMagento\Plugin;
 
 class CsrfValidatorSkip
 {

--- a/Plugin/CsrfValidatorSkip.php
+++ b/Plugin/CsrfValidatorSkip.php
@@ -1,0 +1,23 @@
+<?php
+namespace PayStand\PayStandMagento\Plugin\CsrfValidatorSkip;
+
+class CsrfValidatorSkip
+{
+    /**
+     * @param \Magento\Framework\App\Request\CsrfValidator $subject
+     * @param \Closure $proceed
+     * @param \Magento\Framework\App\RequestInterface $request
+     * @param \Magento\Framework\App\ActionInterface $action
+     */
+    public function aroundValidate(
+        $subject,
+        \Closure $proceed,
+        $request,
+        $action
+    ) {
+        if ($request->getModuleName() == 'paystandmagento') {
+            return; // Skip CSRF check
+        }
+        $proceed($request, $action); // Proceed Magento 2 core functionalities
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -18,13 +18,16 @@
                 <field id="publishable_key" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Publishable Key</label>
                 </field>
-                <field id="client_id" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="customer_id" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Customer Id</label>
+                </field>
+                <field id="client_id" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Client Id</label>
                 </field>
-                <field id="client_secret" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="client_secret" translate="label" type="text" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Client Secret</label>
                 </field>
-                <field id="use_sandbox" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="use_sandbox" translate="label" type="select" sortOrder="6" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use Sandbox</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -18,7 +18,13 @@
                 <field id="publishable_key" translate="label" type="text" sortOrder="2" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Publishable Key</label>
                 </field>
-                <field id="use_sandbox" translate="label" type="select" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                <field id="client_id" translate="label" type="text" sortOrder="3" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Client Id</label>
+                </field>
+                <field id="client_secret" translate="label" type="text" sortOrder="4" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Client Secret</label>
+                </field>
+                <field id="use_sandbox" translate="label" type="select" sortOrder="5" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Use Sandbox</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -7,4 +7,7 @@
             </argument>
         </arguments>
     </type>
+    <type name="Magento\Framework\App\Request\CsrfValidator">
+        <plugin name="csrf_validator_skip" type="PayStand\PayStandMagento\Plugin\CsrfValidatorSkip" />
+    </type>
 </config>

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
-    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local_dev",
+    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
+    //"paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local_dev",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -2,7 +2,7 @@ var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
     // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
+    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local_dev",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,8 +1,8 @@
 var config = {
   paths: {
     "paystand": "https://checkout.paystand.com/v4/js/paystand.checkout.js?env=live",
-    "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
-    // "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
+    // "paystand-sandbox": "https://checkout.paystand.co/v4/js/paystand.checkout.js?env=sandbox",
+    "paystand-sandbox": "https://localhost:3003/js/paystand.checkout.js?env=local",
     "paystand-checkout": "./PayStand_PayStandMagento/js/view/checkout/checkout"
   }
 };

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -5,12 +5,12 @@ var checkout_domain = 'checkout.paystand.com';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  // core_domain = 'paystand.co';
-  // api_domain = 'api.paystand.co';
-  // checkout_domain = 'checkout.paystand.co';
-  core_domain = 'localhost:3001';
-  api_domain = 'localhost:3001/api';
-  checkout_domain = 'localhost:3003';
+  core_domain = 'paystand.co';
+  api_domain = 'api.paystand.co';
+  checkout_domain = 'checkout.paystand.co';
+  // core_domain = 'localhost:3001';
+  // api_domain = 'localhost:3001/api';
+  // checkout_domain = 'localhost:3003';
 }
 
 /*jshint browser:true jquery:true*/
@@ -61,8 +61,7 @@ define([
           "source": "magento 2",
           "quote": quoteId,
           "quoteDetails" : quote.totals()
-        },
-        "viewclose": "hide"
+        }
       };
 
       if (billing.street && billing.street.length > 0) {

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -5,12 +5,12 @@ var checkout_domain = 'checkout.paystand.com';
 var use_sandbox = window.checkoutConfig.payment.paystandmagento.use_sandbox;
 if (use_sandbox == '1') {
   checkoutjs_module = 'paystand-sandbox';
-  core_domain = 'paystand.co';
-  api_domain = 'api.paystand.co';
-  checkout_domain = 'checkout.paystand.co';
-  // core_domain = 'localhost:3001';
-  // api_domain = 'localhost:3001/api';
-  // checkout_domain = 'localhost:3003';
+  // core_domain = 'paystand.co';
+  // api_domain = 'api.paystand.co';
+  // checkout_domain = 'checkout.paystand.co';
+  core_domain = 'localhost:3001';
+  api_domain = 'localhost:3001/api';
+  checkout_domain = 'localhost:3003';
 }
 
 /*jshint browser:true jquery:true*/
@@ -61,7 +61,8 @@ define([
           "source": "magento 2",
           "quote": quoteId,
           "quoteDetails" : quote.totals()
-        }
+        },
+        "viewclose": "hide"
       };
 
       if (billing.street && billing.street.length > 0) {

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -9,7 +9,7 @@ if (use_sandbox == '1') {
   // api_domain = 'api.paystand.co';
   // checkout_domain = 'checkout.paystand.co';
   core_domain = 'localhost:3001';
-  api_domain = 'localhost:3001/api/v3';
+  api_domain = 'localhost:3001/api';
   checkout_domain = 'localhost:3003';
 }
 
@@ -32,7 +32,7 @@ define([
     var publishable_key = window.checkoutConfig.payment.paystandmagento.publishable_key;
 
     var price = quote.totals().grand_total.toString();
-    var quoteId = quote.getId();
+    var quoteId = quote.getQuoteId();
     var billing = quote.billingAddress();
 
     psCheckout.onComplete(function(data){

--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -9,7 +9,7 @@ if (use_sandbox == '1') {
   // api_domain = 'api.paystand.co';
   // checkout_domain = 'checkout.paystand.co';
   core_domain = 'localhost:3001';
-  api_domain = 'localhost:3001/api';
+  api_domain = 'localhost:3001/api/v3';
   checkout_domain = 'localhost:3003';
 }
 
@@ -32,7 +32,7 @@ define([
     var publishable_key = window.checkoutConfig.payment.paystandmagento.publishable_key;
 
     var price = quote.totals().grand_total.toString();
-    var quoteId = quote.getQuoteId();
+    var quoteId = quote.getId();
     var billing = quote.billingAddress();
 
     psCheckout.onComplete(function(data){


### PR DESCRIPTION
JIRA
----
https://paystand.atlassian.net/browse/PPL-133

Description
-----
Paystand plugin for magento 2 was not working correctly. The issues fixed, and new implementations by this PR are listed below:
1) HTTP POST requests were failing due to Magento\Framework\App\Request\CsrfValidator update on Magento 2.3
2) \Magento\Sales\Model\Order->loadByAttribute() was not working. 
3) We are receiving QuoteIdMask, which needs to be translated into an actual quoteId. that was not implemented
4) In order to access a Paystand restricted endpoint, we need x-customer-id and access_token, which can be retrieved using client_id and client_secret. Now it is implemented
5) We need to clean the event before verify due to paystand's endpoint verification.
6) HTTP responses implemented

QA Notes
----
**General Instructions**
Create an order using magento store, and choosing paystand as payment method.
The order status should be "processing" after receiving paystand webhooks.

**Instructions**
0) Update the plugin following Instructions from Paystand's AR -> Integrations -> Magento
1) Go to Magento admin page -> Stores -> Configuration -> Sales -> Payment Method -> Paystand
2) Configure the needed fields: [publishable key, customer id, client id, client secret] 
2.5) Remember that webhook needs to be set on Paystand's AR
3) Go to magento store, add a product to cart, go to checkout and pay the quote using paystand as payment method
4) After the purchase succeed, go to Magento Admin Page -> Orders
5) Search for the order you just created, and it should be with "processing" status.
