### PR TITLE
PLL-133-close: remove close button to prevent closing checkout

### DIFF
--- a/view/frontend/web/js/view/checkout/checkout.js
+++ b/view/frontend/web/js/view/checkout/checkout.js
@@ -60,7 +60,8 @@ define([
           "source": "magento 2",
           "quote": quoteId,
           "quoteDetails" : quote.totals()
-        }
+        },
+        "viewclose": "hide"
       };
 
       if (billing.street && billing.street.length > 0) {


### PR DESCRIPTION
JIRA
----
https://paystand.atlassian.net/browse/PPL-133

Description
-----
When choosing a payment method, if we choose paystand, checkout will popup, however if we close it, we can't open it again unless we refresh the page. This fix, removes the option to close checkout to prevent that behavior

QA Notes
----
follow a purchase flow on Magento 2 store, select paystand as payment method. The close button ("X") should not be available on the checkout window