### PR TITLE
PPL-173: Magento - Content Security Policies error from Magento 2.3.5 new version

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -23,5 +23,15 @@
                 <!--<date_delim>/</date_delim>-->
             </paystandmagento>
         </payment>
+        <csp>
+            <mode>
+                <storefront>
+                    <report_only>1</report_only>
+                </storefront>
+                <admin>
+                    <report_only>1</report_only>
+                </admin>
+            </mode>
+        </csp>
     </default>
 </config>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="script-src">
+            <values>
+                <value id="paystand-checkout-co" type="host">https://checkout.paystad.co</value>
+                <value id="paystand-checkout-com" type="host">https://checkout.paystad.com</value>
+                <value id="paystand-checkout-biz" type="host">https://checkout.paystad.biz</value>
+            </values>
+        </policy>
+        <policy id="style-src">
+            <values>
+                <value id="style-co" type="host">https://checkout.paystad.co</value>
+                <value id="style-com" type="host">https://checkout.paystad.com</value>
+                <value id="style-biz" type="host">https://checkout.paystad.biz</value>
+            </values>
+        </policy>
+        <policy id="frame-src">
+            <values>
+                <value id="frame-co" type="host">https://checkout.paystad.co</value>
+                <value id="frame-com" type="host">https://checkout.paystad.com</value>
+                <value id="frame-biz" type="host">https://checkout.paystad.biz</value>
+            </values>
+        </policy>
+        <policy id="connect-src">
+            <values>
+                <value id="connect-co" type="host">https://checkout.paystad.co</value>
+                <value id="connect-com" type="host">https://checkout.paystad.com</value>
+                <value id="connect-biz" type="host">https://checkout.paystad.biz</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,30 +3,33 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="paystand-checkout-co" type="host">https://checkout.paystad.co</value>
-                <value id="paystand-checkout-com" type="host">https://checkout.paystad.com</value>
-                <value id="paystand-checkout-biz" type="host">https://checkout.paystad.biz</value>
+                <value id="paystand-checkout-co" type="host">https://checkout.paystand.co</value>
+                <value id="paystand-api-co" type="host">https://api.paystad.co</value>
+                <value id="paystand-checkout-com" type="host">https://checkout.paystand.com</value>
+                <value id="paystand-api-com" type="host">https://api.paystad.com</value>
+                <value id="paystand-checkout-biz" type="host">https://checkout.paystand.biz</value>
+                <value id="paystand-api-biz" type="host">https://api.paystad.biz</value>
             </values>
         </policy>
         <policy id="style-src">
             <values>
-                <value id="style-co" type="host">https://checkout.paystad.co</value>
-                <value id="style-com" type="host">https://checkout.paystad.com</value>
-                <value id="style-biz" type="host">https://checkout.paystad.biz</value>
+                <value id="style-co" type="host">https://checkout.paystand.co</value>
+                <value id="style-com" type="host">https://checkout.paystand.com</value>
+                <value id="style-biz" type="host">https://checkout.paystand.biz</value>
             </values>
         </policy>
         <policy id="frame-src">
             <values>
-                <value id="frame-co" type="host">https://checkout.paystad.co</value>
-                <value id="frame-com" type="host">https://checkout.paystad.com</value>
-                <value id="frame-biz" type="host">https://checkout.paystad.biz</value>
+                <value id="frame-co" type="host">https://checkout.paystand.co</value>
+                <value id="frame-com" type="host">https://checkout.paystand.com</value>
+                <value id="frame-biz" type="host">https://checkout.paystand.biz</value>
             </values>
         </policy>
         <policy id="connect-src">
             <values>
-                <value id="connect-co" type="host">https://checkout.paystad.co</value>
-                <value id="connect-com" type="host">https://checkout.paystad.com</value>
-                <value id="connect-biz" type="host">https://checkout.paystad.biz</value>
+                <value id="connect-co" type="host">https://checkout.paystand.co</value>
+                <value id="connect-com" type="host">https://checkout.paystand.com</value>
+                <value id="connect-biz" type="host">https://checkout.paystand.biz</value>
             </values>
         </policy>
     </policies>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -3,12 +3,12 @@
     <policies>
         <policy id="script-src">
             <values>
-                <value id="paystand-checkout-co" type="host">https://checkout.paystand.co</value>
-                <value id="paystand-api-co" type="host">https://api.paystand.co</value>
-                <value id="paystand-checkout-com" type="host">https://checkout.paystand.com</value>
-                <value id="paystand-api-com" type="host">https://api.paystand.com</value>
-                <value id="paystand-checkout-biz" type="host">https://checkout.paystand.biz</value>
-                <value id="paystand-api-biz" type="host">https://api.paystand.biz</value>
+                <value id="script-checkout-co" type="host">https://checkout.paystand.co</value>
+                <value id="script-api-co" type="host">https://api.paystand.co</value>
+                <value id="script-checkout-com" type="host">https://checkout.paystand.com</value>
+                <value id="script-api-com" type="host">https://api.paystand.com</value>
+                <value id="script-checkout-biz" type="host">https://checkout.paystand.biz</value>
+                <value id="script-api-biz" type="host">https://api.paystand.biz</value>
             </values>
         </policy>
         <policy id="style-src">
@@ -28,8 +28,11 @@
         <policy id="connect-src">
             <values>
                 <value id="connect-co" type="host">https://checkout.paystand.co</value>
+                <value id="connect-api-co" type="host">https://api.paystand.co</value>
                 <value id="connect-com" type="host">https://checkout.paystand.com</value>
+                <value id="connect-api-com" type="host">https://api.paystand.com</value>
                 <value id="connect-biz" type="host">https://checkout.paystand.biz</value>
+                <value id="connect-api-biz" type="host">https://api.paystand.biz</value>
             </values>
         </policy>
     </policies>

--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -4,11 +4,11 @@
         <policy id="script-src">
             <values>
                 <value id="paystand-checkout-co" type="host">https://checkout.paystand.co</value>
-                <value id="paystand-api-co" type="host">https://api.paystad.co</value>
+                <value id="paystand-api-co" type="host">https://api.paystand.co</value>
                 <value id="paystand-checkout-com" type="host">https://checkout.paystand.com</value>
-                <value id="paystand-api-com" type="host">https://api.paystad.com</value>
+                <value id="paystand-api-com" type="host">https://api.paystand.com</value>
                 <value id="paystand-checkout-biz" type="host">https://checkout.paystand.biz</value>
-                <value id="paystand-api-biz" type="host">https://api.paystad.biz</value>
+                <value id="paystand-api-biz" type="host">https://api.paystand.biz</value>
             </values>
         </policy>
         <policy id="style-src">


### PR DESCRIPTION
JIRA
----
https://paystand.atlassian.net/browse/PPL-173

Description
----
As of version 2.3.5, Magento supports CSP (Content Security Policies) headers and provides ways to configure them. (This functionality is defined in the Magento_Csp module.)
On this PR we are adding CSP configuration for Paystand Module in order to be compliant with this functionality on Magento 2.3.5 so it doesn't show errors on the console when "report only" is configured, and don't cause the module to fail when "restrict" mode is configured on the Magento store.

QA Notes
----
Go to our magento store (magento.paystand.biz) open the developer tools and select console, purchase something with Paystand Payment method, and make sure your order gets from "pending" to "processing" status. You can test multiple payment rails, fee scenarios and create orders as a logged in user. **But what you really want to make sure of** is that during all of this, you don't get errors (warnings are ok) on the console saying "Refused to load/connect/frame <paystandDomain/resource> because it violates the following Content Security Policy directive"

**EXAMPLE OF BAD BEHAVIOR**
![image](https://user-images.githubusercontent.com/33076382/85632511-146a6a00-b63d-11ea-8b0f-89858e00ab04.png)

As you can see there are many errors and warnings, this is due to the new feature of CSP instroduced on Magento 2.3.5, the only ones we care are the ones with this pattern: "Refused to load/connect/frame <paystandDomain/resource> because it violates the following Content Security Policy directive" (i.e. The error at the top, the warnings and other domain errors (google, paypal, etc) are not related).

