### PR TITLE
PPL-184: Created and processing webhook events are returning a 401 response

### DIFF
--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -115,7 +115,7 @@ class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostA
             \Magento\Sales\Model\Order::class
         )->loadByIncrementId($quote->getReservedOrderId());
         // alternate method in case the environment is not using increment_id on the order.
-        if(empty($order)){
+        if (empty($order)) {
             $order = $this->_objectManager->create(
                 \Magento\Sales\Model\Order::class
             )->load($quote->getReservedOrderId());

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -114,6 +114,12 @@ class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostA
         $order = $this->_objectManager->create(
             \Magento\Sales\Model\Order::class
         )->loadByIncrementId($quote->getReservedOrderId());
+        // alternate method in case the environment is not using increment_id on the order.
+        if(empty($order)){
+            $order = $this->_objectManager->create(
+                \Magento\Sales\Model\Order::class
+            )->load($quote->getReservedOrderId());
+        }
 
         // Verify we got an existing Magento order from received quote id
         if (empty($order->getIncrementId())) {

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -6,11 +6,12 @@ use \Magento\Framework\App\Config\ScopeConfigInterface as ScopeConfig;
 use \Magento\Quote\Model\QuoteFactory as QuoteFactory;
 use \Magento\Quote\Model\QuoteIdMaskFactory as QuoteIdMaskFactory;
 use \stdClass;
+use Magento\Framework\App\Action\HttpPostActionInterface as HttpPostActionInterface;
 
 /**
  * Webhook Receiver Controller for Paystand
  */
-class Paystand extends \Magento\Framework\App\Action\Action
+class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostActionInterface
 {
 
     // Get configuration from Paystand's payment method settings & set constants
@@ -80,7 +81,7 @@ class Paystand extends \Magento\Framework\App\Action\Action
         $this->_logger->debug('>>>>> PAYSTAND-START: paystandmagento/webhook/paystand endpoint was hit');
 
         // Get body content from request
-        $body = $this->getRequest()->getContent();
+        $body = $this->_request->getContent() ?? $this->getRequest()->getContent();
         if ($body == null) {
             $this->_logger->error('>>>>> PAYSTAND-ERROR: error retrieving the body from webhook');
             $result->setHttpResponseCode(\Magento\Framework\Webapi\Exception::HTTP_INTERNAL_ERROR);
@@ -175,7 +176,7 @@ class Paystand extends \Magento\Framework\App\Action\Action
         $state = $newStatus;
         $status = $newStatus;
 
-        // Assing new status to Magento 2 Order
+        // Assign new status to Magento 2 Order
         $order->setState($state);
         $order->setStatus($status);
         $order->save();

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -112,7 +112,7 @@ class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostA
         $quote = $this->_quoteFactory->create()->load($id);
         $order = $this->_objectManager->create(
             \Magento\Sales\Model\Order::class
-        )->load($quote->getReservedOrderId());
+        )->loadByIncrementId($quote->getReservedOrderId());
 
         // Verify we got an existing Magento order from received quote id
         if (empty($order->getIncrementId())) {

--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -81,7 +81,8 @@ class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostA
         $this->_logger->debug('>>>>> PAYSTAND-START: paystandmagento/webhook/paystand endpoint was hit');
 
         // Get body content from request
-        $body = $this->_request->getContent() ?? $this->getRequest()->getContent();
+        $body = (!empty($this->_request->getContent()))
+            ? $this->_request->getContent() : $this->getRequest()->getContent();
         if ($body == null) {
             $this->_logger->error('>>>>> PAYSTAND-ERROR: error retrieving the body from webhook');
             $result->setHttpResponseCode(\Magento\Framework\Webapi\Exception::HTTP_INTERNAL_ERROR);


### PR DESCRIPTION
JIRA
----
https://paystand.atlassian.net/browse/PPL-184

Description
----
Even though in our local environment and biz environment for magento 2 stores, the webhook flow was working correctly, for NVG's environment this was not working. 
**Root cause**
https://magento.stackexchange.com/questions/46674/why-load-is-different-from-loadbyincrementid-for-sales-order-model (Their environments have been using the increment_id instead of entity_id)
So with their help we managed to identify a couple of places where we can add a second way of retrieve the required data in case the first one fails.

QA Notes
----
**Check with Jose before QA to make sure our magento instance "magento.paystand.biz" has this code.
We are changing the webhook file, so we need to test:
1) When we create an order in our store, the order goes to "processing" status after we purchased an item **for guest sale and for a logged in user**
2) Make sure everything works as expected:
- Do not process webhooks where the object is not "payment"
- Do not process webhooks where payment status is either "created" or "processing"
- Send an error if the webhook is tampered (change any value in the body)
- Only change order to "Processing" if webhook for payment is in "posted" or "paid" status

**To test the above** you can set the webhook in Paystand to webhook.site apart of the magento store, so you get the webhook data and can reproduce them with POSTMAN



