### PR TITLE
PPL-225: Magento - plugin updating order status twice [FIX]

### DIFF
--- a/Controller/webhook/PayStand.php
+++ b/Controller/webhook/PayStand.php
@@ -185,11 +185,16 @@ class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostA
         }
 
         // Get new order state & status depending on Paystand's payment status
-        if ($json->resource->status == 'created' || $json->resource->status == 'processing') {
-            $this->_logger->debug('>>>>> PAYSTAND-FINISH: payment created or processing, no need to update order');
+        if ($json->resource->status == 'created'
+                || $json->resource->status == 'processing'
+                || $json->resource->status == 'paid'
+            ) {
+            $this->_logger->debug(
+                '>>>>> PAYSTAND-FINISH: payment created, processing or paid, no need to update order'
+            );
             $result->setHttpResponseCode(\Magento\Framework\Webapi\Response::HTTP_OK);
             $result->setData(
-                ['success_message' => __('Event verified, payment created or processing, no further action')]
+                ['success_message' => __('Event verified, payment created, processing or paid, no further action')]
             );
             return $result;
         }
@@ -278,9 +283,6 @@ class Paystand extends \Magento\Framework\App\Action\Action implements HttpPostA
         $newStatus = '';
         switch ($status) {
             case 'posted':
-                $newStatus = Order::STATE_PROCESSING;
-                break;
-            case 'paid':
                 $newStatus = Order::STATE_PROCESSING;
                 break;
             case 'failed':


### PR DESCRIPTION
JIRA
----
https://paystand.atlassian.net/browse/PPL-225

Description
----
Previously, when the magento store received **posted** and **paid** events from Paystand's payment, it updated the related order status to processing, now it will only do it on **posted** event to prevent external workflows conflict

QA Notes
----
**Check with Jose before QA to make sure our magento instance "magento.paystand.biz" has this code.
**Prerequisites**:
In order to QA this, you will need to monitor the magento's store logs, to do it, ask Omar B for access to magento.paystand.biz server.
a) ssh into the server (ie. ssh jbeltran@magento.paystand.biz)
b) enter the docker container: (ie. docker exec -it magento bash)
c) watch magento logs (ie. tail -f var/logs/debug.log)
1) Go to magento.paystand.biz
2) Add a product to your cart, and follow the process of buying it paying with paystand
3) Now monitor the logs, you will see a lot of them, but use cmd+f to search for ">>>>> PAYSTAND-REQUEST-RECEIVED:" this will show you the paystand event that magento just received. follow the logs and make sure the following happens **in below order** 

| Paystand Event  | Expected behavior | Notes |
| ------------- | ------------- | ------------ |
| Card created  | >>>>> PAYSTAND-FINISH: not a Paystand-Magento request  | |
| Payment created  | >>>>> PAYSTAND-FINISH: payment created, processing or paid, no need to update order  | this event might fail a couple of times before it actually succeeds, with the error: **Could not retrieve order from quoteId**. This is normal since the order might not be yet created when the event is received, this error will cause for this event to be sent again in a minute or two |
| Payment processing  | >>>>> PAYSTAND-FINISH: payment created, processing or paid, no need to update order  | |
| Payment posted  | >>>>> PAYSTAND-FINISH: Paystand payment status: posted, new order state: processing, new order status: processing  | |
| Payment paid  | >>>>> PAYSTAND-FINISH: payment created, processing or paid, no need to update order  | |